### PR TITLE
Fix Electron app authentication: Replace API token input with email/p…

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -66,6 +66,7 @@ router.post('/change-password', authenticateToken, validatePasswordChange, AuthC
 router.post('/generate-api-token', authenticateToken, AuthController.generateApiToken);
 
 // API token routes (for desktop app)
+router.get('/api-profile', authenticateApiToken, AuthController.getProfile);
 router.post('/logout', authenticateApiToken, AuthController.logout);
 
 module.exports = router;

--- a/desktop_app/src/renderer/index.html
+++ b/desktop_app/src/renderer/index.html
@@ -12,13 +12,18 @@
         <div id="login-screen" class="screen">
             <div class="header">
                 <h1>Mercor Time Tracker</h1>
-                <p>Enter your API token to get started</p>
+                <p>Sign in to your account</p>
             </div>
             
             <form id="login-form">
                 <div class="form-group">
-                    <label for="api-token">API Token</label>
-                    <input type="password" id="api-token" placeholder="Enter your API token" required>
+                    <label for="email">Email</label>
+                    <input type="email" id="email" placeholder="Enter your email" required>
+                </div>
+                
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" placeholder="Enter your password" required>
                 </div>
                 
                 <button type="submit" id="login-btn" class="btn btn-primary">
@@ -30,8 +35,8 @@
             </form>
             
             <div class="help-text">
-                <p>Don't have an API token?</p>
-                <p>Check your email for the verification link or contact your administrator.</p>
+                <p>Need help with your account?</p>
+                <p>Contact your administrator for assistance.</p>
             </div>
         </div>
 

--- a/desktop_app/src/renderer/renderer.js
+++ b/desktop_app/src/renderer/renderer.js
@@ -21,7 +21,8 @@ class TimeTrackerUI {
 
     // Login elements
     this.loginForm = document.getElementById('login-form');
-    this.apiTokenInput = document.getElementById('api-token');
+    this.emailInput = document.getElementById('email');
+    this.passwordInput = document.getElementById('password');
     this.loginBtn = document.getElementById('login-btn');
     this.loginError = document.getElementById('login-error');
 
@@ -90,9 +91,11 @@ class TimeTrackerUI {
   async handleLogin(e) {
     e.preventDefault();
     
-    const apiToken = this.apiTokenInput.value.trim();
-    if (!apiToken) {
-      this.showError('Please enter your API token');
+    const email = this.emailInput.value.trim();
+    const password = this.passwordInput.value.trim();
+    
+    if (!email || !password) {
+      this.showError('Please enter both email and password');
       return;
     }
 
@@ -100,7 +103,7 @@ class TimeTrackerUI {
     this.hideError();
 
     try {
-      const result = await ipcRenderer.invoke('authenticate', apiToken);
+      const result = await ipcRenderer.invoke('login', { email, password });
       
       if (result.success) {
         this.currentUser = result.user;
@@ -125,7 +128,8 @@ class TimeTrackerUI {
       this.selectedProject = null;
       this.stopTrackingUI();
       this.showLoginScreen();
-      this.apiTokenInput.value = '';
+      this.emailInput.value = '';
+      this.passwordInput.value = '';
     } catch (error) {
       console.error('Logout error:', error);
     }


### PR DESCRIPTION
…assword login form

- Modified desktop app UI to show email/password fields instead of API token field
- Updated renderer.js to handle email/password authentication flow
- Added new login IPC handler in main.js for email/password authentication
- Enhanced ApiClient with login() method that authenticates with email/password and auto-generates API token
- Added /api/auth/api-profile endpoint for API token authentication
- Fixed authentication flow: email/password → JWT → API token → stored for future API calls
- Resolves chicken-and-egg problem where users needed API token but couldn't get one without first logging in